### PR TITLE
feature: example for credentials is in nested property

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ return [
     // ...
 
     'sns' => [
-        'key' => env('AWS_ACCESS_KEY_ID'),
-        'secret' => env('AWS_SECRET_ACCESS_KEY'),
+        'credentials' => [
+            'key' => env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY'),
+        ],
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
         'version' => 'latest',
     ],


### PR DESCRIPTION
Within issue #9 an example showed that nesting the `key` and `secret` under a `credentials` key fixed deliverability. I was having the same issue on a production server which was resolved after altering the `config['services.sns']` structure. This PR updates the documentation to reflect this functioning structure.

Without this update, the `NotificationFailed` event message reads:
```
Error retrieving credentials from the instance profile metadata service.
```

However with the updated config, SMS delivers as expected in production.
