### PR TITLE
feature: Add support to anonymous notifiables.

### DIFF
--- a/src/SnsChannel.php
+++ b/src/SnsChannel.php
@@ -3,6 +3,7 @@
 namespace NotificationChannels\AwsSns;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Notification;
 use NotificationChannels\AwsSns\Exceptions\CouldNotSendNotification;
@@ -55,7 +56,11 @@ class SnsChannel
      */
     protected function getDestination($notifiable, Notification $notification)
     {
-        if ($to = $notifiable->routeNotificationFor('sns', $notification)) {
+        if (
+            $notifiable instanceof AnonymousNotifiable
+            && ($to = $notifiable->routeNotificationFor(self::class))
+            || ($to = $notifiable->routeNotificationFor('sns', $notification))
+        ) {
             return $to;
         }
 

--- a/src/SnsChannel.php
+++ b/src/SnsChannel.php
@@ -3,7 +3,6 @@
 namespace NotificationChannels\AwsSns;
 
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Notification;
 use NotificationChannels\AwsSns\Exceptions\CouldNotSendNotification;
@@ -56,11 +55,7 @@ class SnsChannel
      */
     protected function getDestination($notifiable, Notification $notification)
     {
-        if (
-            $notifiable instanceof AnonymousNotifiable
-            && ($to = $notifiable->routeNotificationFor(self::class))
-            || ($to = $notifiable->routeNotificationFor('sns', $notification))
-        ) {
+        if ($to = $notifiable->routeNotificationFor('sns', $notification)) {
             return $to;
         }
 

--- a/tests/SnsChannelTest.php
+++ b/tests/SnsChannelTest.php
@@ -124,7 +124,7 @@ class SnsChannelTest extends TestCase
         $notification->shouldReceive('toSns')->andReturn('Message text');
 
         $phoneNumber = '+22222222222';
-        $anonymousNotifiable = NotificationFacade::route(SnsChannel::class, $phoneNumber);
+        $anonymousNotifiable = NotificationFacade::route('sns', $phoneNumber);
 
         $this->sns->shouldReceive('send')
             ->atLeast()->once()

--- a/tests/SnsChannelTest.php
+++ b/tests/SnsChannelTest.php
@@ -5,12 +5,12 @@ namespace NotificationChannels\AwsSns\Test;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
 use Mockery;
 use NotificationChannels\AwsSns\Sns;
 use NotificationChannels\AwsSns\SnsChannel;
 use NotificationChannels\AwsSns\SnsMessage;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Support\Facades\Notification as NotificationFacade;
 
 class SnsChannelTest extends TestCase
 {

--- a/tests/SnsChannelTest.php
+++ b/tests/SnsChannelTest.php
@@ -10,6 +10,7 @@ use NotificationChannels\AwsSns\Sns;
 use NotificationChannels\AwsSns\SnsChannel;
 use NotificationChannels\AwsSns\SnsMessage;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
 
 class SnsChannelTest extends TestCase
 {
@@ -114,6 +115,22 @@ class SnsChannelTest extends TestCase
             ->with(Mockery::type(NotificationFailed::class));
 
         $this->channel->send($notifiable, $notification);
+    }
+
+    /** @test */
+    public function it_will_send_a_sms_to_an_anonymous_notifiable()
+    {
+        $notification = Mockery::mock(Notification::class);
+        $notification->shouldReceive('toSns')->andReturn('Message text');
+
+        $phoneNumber = '+22222222222';
+        $anonymousNotifiable = NotificationFacade::route(SnsChannel::class, $phoneNumber);
+
+        $this->sns->shouldReceive('send')
+            ->atLeast()->once()
+            ->with(Mockery::type(SnsMessage::class), $phoneNumber);
+
+        $this->channel->send($anonymousNotifiable, $notification);
     }
 }
 


### PR DESCRIPTION
I was having an issue when using the [Notification Facade](https://laravel.com/api/8.x/Illuminate/Support/Facades/Notification.html) to send a sms to anonymous users.
This is easily fixed by checking if the notifiable is instanceof [AnonymousNotifiable](https://laravel.com/api/8.x/Illuminate/Notifications/AnonymousNotifiable.html) then get the phone number by passing the channel name to the [AnonymousNotifiable::routeNotificationFor()](https://laravel.com/api/8.x/Illuminate/Notifications/AnonymousNotifiable.html#method_routeNotificationFor) method.



This pull request adds support to Laravel's  Notification Facade:
```php
use NotificationChannels\AwsSns\SnsChannel;
use Illuminate\Support\Facades\Notification;
// ...

Notification::route(SnsChannel::class, '+22222222222')
    ->notify(new MyCoolNotification());
```

Sorry for my bad english, i hope i was able to explain the problem.