### PR TITLE
Require PHP 8.1+

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,33 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.1, 8.0, 7.4, 7.3, 7.2 ]
-        laravel: [ 9.*, 8.*, 7.*, 6.*, ~5.5 , 10.*]
+        php: [ 8.1, 8.2 ]
+        laravel: [ 9.*, 10.*]
         dependency-version: [ prefer-lowest, prefer-stable ]
-        exclude:
-          # Laravel 9 Supports PHP 8.0 - 8.1
-          - laravel: 9.*
-            php: 7.4
-          - laravel: 9.*
-            php: 7.3
-          - laravel: 9.*
-            php: 7.2
-          # Laravel 8 Supports PHP 7.3 - 8.1
-          - laravel: 8.*
-            php: 7.2
-          # Laravel 7 Supports PHP 7.2 - 8.0
-          - laravel: 7.*
-            php: 8.1
-          # Laravel 6 Supports PHP 7.2 - 8.0
-          - laravel: 6.*
-            php: 8.1
-          # Laravel 5.5 Supports PHP 7.0 - 7.3
-          - laravel: ~5.5
-            php: 8.1
-          - laravel: ~5.5
-            php: 8.0
-          - laravel: ~5.5
-            php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.4.1",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^9.5.10"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/support": "^9.0|^10.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.4.1",
+        "mockery/mockery": "^1.5.1",
         "phpunit/phpunit": "^9.5.10"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=8.1",
         "aws/aws-sdk-php": "^3.69.11",
         "guzzlehttp/guzzle": "^6.2.1 || ^7.0",
-        "illuminate/notifications": "~5.5 || ~6.0 || ~7.0 || ~8.0 || ~9.0|^10.0",
-        "illuminate/support": "~5.5 || ~6.0 || ~7.0 || ~8.0 || ~9.0|^10.0"
+        "illuminate/notifications": "^9.0|^10.0",
+        "illuminate/support": "^9.0|^10.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.3.5",
-        "phpunit/phpunit": "^8.5.23|^9.5.10"
+        "mockery/mockery": "^1.4.1",
+        "phpunit/phpunit": "^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="AwsSns Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="AwsSns Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-    <report>
-      <clover outputFile="build/logs/clover.xml"/>
-      <html outputDirectory="build/coverage"/>
-      <text outputFile="build/coverage.txt"/>
-    </report>
-  </coverage>
-  <testsuites>
-    <testsuite name="AwsSns Test Suite">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
-  <logging>
-    <junit outputFile="build/report.junit.xml"/>
-  </logging>
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="AwsSns Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="tap" target="build/report.tap"/>
+        <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-html" target="build/coverage"/>
+        <log type="coverage-text" target="build/coverage.txt"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
 </phpunit>


### PR DESCRIPTION
This drops support for older versions of PHP and older versions of Laravel.

Let's target PHP 8.1+ (the currently supported versions of PHP) and Laravel 9.x/10.x (the current, and next version of Laravel).

If you're running older versions of PHP or Laravel you can continue to use a previous version of the channel.